### PR TITLE
Adress #11: Exclude trait methods from export

### DIFF
--- a/src/Pharo2VW-Tests/Pharo2VWExporterTest.class.st
+++ b/src/Pharo2VW-Tests/Pharo2VWExporterTest.class.st
@@ -81,7 +81,7 @@ Pharo2VWExporterTest >> testExampleExportLan [
 Pharo2VWExporterTest >> testExampleExportPackageBasicClasses [
 	| inst classes |
 	inst := Pharo2VWExamples new.
-	classes := (inst exampleExportPackageBasic) classes.
+	classes := (inst exampleExportPackageBasic) classes select: #isClass.
 	self parseGeneratedXML.
 	self
 		assert: (self xPathFor: '//class') size

--- a/src/Pharo2VW/Pharo2VW.class.st
+++ b/src/Pharo2VW/Pharo2VW.class.st
@@ -165,9 +165,10 @@ Pharo2VW >> fileOutInitializerForClass: aClass [
 ]
 
 { #category : #export }
-Pharo2VW >> fileOutInitializers [		
-	(self classes select: [:c | c class includesSelector: #initialize])
-		do: [:class | self fileOutInitializerForClass: class].
+Pharo2VW >> fileOutInitializers [
+	(self classes
+		select: [ :c | c isClass and: [ c class includesSelector: #initialize ] ])
+		do: [ :class | self fileOutInitializerForClass: class ]
 ]
 
 { #category : #export }
@@ -293,9 +294,9 @@ Pharo2VW >> methods [
 		self packagesTags do: [ :pkg | 
 			methods addAll: (pkg package extensionsForTag: pkg).
 			pkg classes do: [ :cls | 
-				cls isTrait ifFalse: [ 
-					methods addAll: cls class methods ].
-				methods addAll: cls methods ] ].
+				cls isClass ifTrue: [ 
+					methods addAll: cls class methods.
+					methods addAll: cls methods ] ] ].
 		methods ].
 ]
 


### PR DESCRIPTION
Exclude methods defined in traits from export

Trait definitions are already excluded from the export and their methods
are flattened into the using classes. Exporting trait methods seperately
breaks the import in VW, as the corresponding class-id is undefined.

This commit
a) excludes trait methods and initializers and
b) changes the filter to #isClass instead of #isTrait for consistency.